### PR TITLE
Replaced 'arch-update' by 'crystal-update'

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,12 +3,12 @@
 
 pkgname=onyx
 pkgver=1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="The custom GNOME Session for Crystal Linux"
 arch=('any')
 url="https://getcryst.al"
 license=('GPL')
-depends=('baobab' 'eog' 'evince' 'file-roller' 'gdm' 'gedit' 'gnome-backgrounds' 'gnome-calculator' 'gnome-calendar' 'gnome-characters' 'gnome-clocks' 'gnome-color-manager' 'gnome-control-center' 'gnome-disk-utility' 'gnome-font-viewer' 'gnome-keyring' 'gnome-menus' 'gnome-settings-daemon' 'gnome-shell' 'gnome-software' 'gnome-system-monitor' 'gnome-terminal' 'gnome-user-docs' 'gnome-user-share' 'gnome-video-effects' 'gnome-weather' 'grilo-plugins' 'gvfs' 'gvfs-afc' 'gvfs-goa' 'gvfs-google' 'gvfs-gphoto2' 'gvfs-mtp' 'gvfs-nfs' 'gvfs-smb' 'malcontent' 'mutter' 'nautilus' 'orca' 'sushi' 'tracker3-miners' 'vino' 'xdg-user-dirs-gtk' 'gnome-shell-extension-dash-to-panel' 'gnome-shell-extension-arch-update' 'gnome-shell-extension-gsconnect' 'gnome-shell-extension-caffeine' 'gnome-shell-extension-appindicator' 'xdg-desktop-portal-gtk' 'xdg-desktop-portal-gnome')
+depends=('baobab' 'eog' 'evince' 'file-roller' 'gdm' 'gedit' 'gnome-backgrounds' 'gnome-calculator' 'gnome-calendar' 'gnome-characters' 'gnome-clocks' 'gnome-color-manager' 'gnome-control-center' 'gnome-disk-utility' 'gnome-font-viewer' 'gnome-keyring' 'gnome-menus' 'gnome-settings-daemon' 'gnome-shell' 'gnome-software' 'gnome-system-monitor' 'gnome-terminal' 'gnome-user-docs' 'gnome-user-share' 'gnome-video-effects' 'gnome-weather' 'grilo-plugins' 'gvfs' 'gvfs-afc' 'gvfs-goa' 'gvfs-google' 'gvfs-gphoto2' 'gvfs-mtp' 'gvfs-nfs' 'gvfs-smb' 'malcontent' 'mutter' 'nautilus' 'orca' 'sushi' 'tracker3-miners' 'vino' 'xdg-user-dirs-gtk' 'gnome-shell-extension-dash-to-panel' 'gnome-shell-extension-crystal-update' 'gnome-shell-extension-gsconnect' 'gnome-shell-extension-caffeine' 'gnome-shell-extension-appindicator' 'xdg-desktop-portal-gtk' 'xdg-desktop-portal-gnome')
 source=("00_onyx.gschema.override"
 	"onyx.desktop"
 	"onyx.json"


### PR DESCRIPTION
Hi,

Since we validated `crystal-update` from a functional stand point, here's the anticipated PR to replace `gnome-shell-extension-arch-update` by `gnome-shell-extension-crystal-update` in `onyx` dependencies.

I will create the `gnome-shell-extension-crystal-update`'s PKGBUILD as soon as we'll have a release for it, and then PR it's addition to `malachite/repo` accordingly.

This switch will involve a manual intervention for current `onyx` users. I summed up everything on discord but don't hesitate to ask me everything again if needed :)