### PR TITLE
`arch-update` -> `crystal-update` Refactor

### DIFF
--- a/00_onyx.gschema.override
+++ b/00_onyx.gschema.override
@@ -10,7 +10,7 @@ edge-tiling = true
 center-new-windows = true
 
 [org.gnome.shell:onyx]
-enabled-extensions = ['dash-to-panel@jderose9.github.com', 'ding@rastersoft.com', 'arch-update@RaphaelRochet', 'gsconnect@andyholmes.github.io', 'caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'space-bar@luchrioh']
+enabled-extensions = ['dash-to-panel@jderose9.github.com', 'ding@rastersoft.com', 'crystal-update@CrystalTeam', 'gsconnect@andyholmes.github.io', 'caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'space-bar@luchrioh']
 
 #####################
 # Touchpad settings #

--- a/onyx.json
+++ b/onyx.json
@@ -3,7 +3,7 @@
     "stylesheetName": "gnome-shell.css",
     "enabledExtensions": [
         "dash-to-panel@jderose9.github.com",
-        "arch-update@RaphaelRochet",
+        "crystal-update@CrystalTeam",
         "gsconnect@andyholmes.github.io",
         "caffeine@patapon.info",
         "appindicatorsupport@rgcjonas.gmail.com",


### PR DESCRIPTION
Refactors all instances of `arch-update` to `crystal-update`, including enabled default extensions in Onyx